### PR TITLE
added ir value in the colour sensor

### DIFF
--- a/src/RICRoboticalAddOns.ts
+++ b/src/RICRoboticalAddOns.ts
@@ -129,6 +129,14 @@ const ADDON_COLOURSENSOR_FORMAT_DEF = {
       postMult: 1,
       postAdd: 0,
     },
+    {
+      type: RICDataExtractorVarType.VAR_UNSIGNED,
+      suffix: 'Val',
+      atBit: 50,
+      bits: 16,
+      postMult: 1.0,
+      postAdd: 0,
+    },
   ],
 };
 


### PR DESCRIPTION
Colour sensors also reported an IR value but so far we were not reading it. I added another property in the vals object of the colour sensor: val. Val is the value of the IR sensor on the colour sensor.